### PR TITLE
Fix installers.py for aarch64

### DIFF
--- a/awscliv2/installers.py
+++ b/awscliv2/installers.py
@@ -116,13 +116,13 @@ def install_multiplatform() -> None:
     Install AWS CLI v2 for Linux ar MacOS.
     """
     os_platform = platform.system()
-    arch = platform.architecture()[0]
+    arch = platform.machine()
 
     if os_platform == "Darwin":
         return install_macos()
-    if os_platform == "Linux" and arch == "64bit":
+    if os_platform == "Linux" and arch == "x86_64":
         return install_linux_x86_64()
-    if os_platform == "Linux" and arch == "arm":
+    if os_platform == "Linux" and arch == "aarch64":
         return install_linux_arm()
 
     raise InstallError(f"{os_platform} {arch} is not supported, use docker version")


### PR DESCRIPTION
The `installers.py` script relies on `platform.architecture()[0]` to differentiate between `x86_64` and `aarch64`, however, that value will return `64bit` for both.

Replaced the code to make use of `platform.machine()` that will provide different values.

Running on an x86_64 system:
```
$ python -c "import platform;print(platform.machine())"
x86_64
```

Running on an arm system:
```
$ python -c "import platform;print(platform.machine())"
aarch64
```

Without this patch awscliv2 will install the x86_64 on arm systems and fail to execute