### PR TITLE
Fix interactive_process.py for WindowsOS (avoid winError 10038)

### DIFF
--- a/awscliv2/interactive_process.py
+++ b/awscliv2/interactive_process.py
@@ -6,6 +6,8 @@ import select
 import subprocess
 import sys
 import threading
+import socket
+import platform
 from subprocess import Popen
 from typing import Sequence, TextIO
 
@@ -64,7 +66,11 @@ class InteractiveProcess:
             if self.finished:
                 break
 
-            rlist = select.select([stdin], [], [], self.read_timeout)[0]
+            if platform.system() == "Windows":
+                rlist = select.select([socket.socket()], [], [], self.read_timeout)[0]
+            else:
+                rlist = select.select([stdin], [], [], self.read_timeout)[0]
+
             if not rlist:
                 continue
 


### PR DESCRIPTION
If I installed and executed awscli on Windows OS, `WinError 10038` is returned.
To avoid this error, we can add the condition whether Windows OS or not. 

```
# when I executed in Windows OS environment as below code, WinError 10038 is returned.
# Code

from awscliv2.api import AWSAPI
from awscliv2.exceptions import AWSCLIError

aws_api = AWSAPI()

    try:
        output = aws_api.execute(["sts", "get-session-token"])
    except AWSCLIError as e:
        print(f"Something went wrong: {e}")
    else:
        print(output)

# error message is here.
# File "...\.venv\lib\site-packages\awscliv2\interactive_process.py", line 72, in readall
    rlist = select.select([stdin], [], [], self.read_timeout)[0]
# OSError: [WinError 10038] OSError: [WinError 10038] an operation was attempted on something that is not a socket
```