### PR TITLE
Fix CPU spinlock in _run_detached_subprocess

### DIFF
--- a/awscliv2/api.py
+++ b/awscliv2/api.py
@@ -71,7 +71,10 @@ class AWSAPI:
         p = subprocess.Popen(cmd, encoding=self.encoding)
         return_code: Optional[int] = None
         while return_code is None:
-            return_code = p.poll()
+            try:
+                return_code = p.wait(timeout=1)
+            except subprocess.TimeoutExpired:
+                return_code = None
 
         if return_code:
             raise AWSCLIError(f"Command {shlex.join(cmd)} failed with code {return_code}")


### PR DESCRIPTION
I had an issue where the wrapper would use an entire CPU core, appeared to be due to calling poll() in a spinlock. By using the wait() instead it sleeps for ~ a millisecond in it's own loop preventing the huge CPU cost. I don't think anyone is going to notice an extra millisecond after the CLI exits, so perhaps this is the simplest fix?